### PR TITLE
Improve import tests for Python bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,12 +111,16 @@ commands:
             cd bindings/python && \
             USE_CUDA=<< parameters.use_cuda >> python setup.py install
   run_python_tests:
+    parameters:
+      use_cuda:
+        type: string
+        default: "ON"
     steps:
       - run:
           name: "Run Python Binding Tests"
           command: |
             cd bindings/python/test &&  \
-            python -m unittest discover -v .
+            USE_CUDA=<< parameters.use_cuda >> python -m unittest discover -v .
   test_with_external_project:
     parameters:
       build_shared_libs:
@@ -203,7 +207,8 @@ commands:
           use_cuda: << parameters.use_cuda >>
       - install_python_bindings:
           use_cuda: << parameters.use_cuda >>
-      - run_python_tests
+      - run_python_tests:
+          use_cuda: << parameters.use_cuda >>
 
 jobs:
   ubuntu_20_gcc_9:
@@ -273,7 +278,8 @@ jobs:
       - install_macos_build_dependencies
       - install_python_bindings:
           use_cuda: "OFF"
-      - run_python_tests
+      - run_python_tests:
+          use_cuda: "OFF"
 
   windows_msvc:
     parameters:

--- a/bindings/python/test/test_import.py
+++ b/bindings/python/test/test_import.py
@@ -1,16 +1,39 @@
 """
 Copyright (c) Facebook, Inc. and its affiliates.
-
 This source code is licensed under the MIT-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
+import logging
 import os
+import unittest
 
 
-def test_import_lib_audio():
-    from flashlight.lib.audio import feature as fl_feat
+class ImportTestCase(unittest.TestCase):
+    def test_import_lib_sequence(self):
+        from flashlight.lib.sequence import criterion
+        from flashlight.lib.sequence.criterion import (
+            CpuForceAlignmentCriterion,
+            CpuFullConnectionCriterion,
+            CpuViterbiPath,
+            CriterionScaleMode,
+        )
+
+        if os.getenv("USE_CUDA", "OFF").upper() not in [
+            "OFF",
+            "0",
+            "NO",
+            "FALSE",
+            "N",
+        ]:
+            from flashlight.lib.sequence.flashlight_lib_sequence_criterion import (
+                CudaForceAlignmentCriterion,
+                CudaFullConnectionCriterion,
+                CudaViterbiPath,
+            )
+        else:
+            logging.info("Flashlight Sequence bindings built without CUDA")
 
 
-def test_import_lib_sequence():
-    from flashlight.lib.sequence import criterion as fl_crit
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
See title -- use `unittest` and properly condition on if bindings were installed with CUDA support when testing.

Test plan: CI