### PR TITLE
Fix python namespace packaging + Flashlight pkgs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
           name: "Install Build Dependencies"
           command: |
             sudo apt -y update && \
-            sudo apt -y install build-essential python3-dev python3-pip cmake
+            sudo apt -y install build-essential python3-dev python3-pip python3-venv cmake
       - when:
           condition:
             equal: ["ON", << parameters.use_cuda >>]
@@ -99,19 +99,24 @@ commands:
         default: "ON"
     steps:
       - run:
+          name: "Setup virtualenv"
+          command: |
+            python3 -m venv venv
+            echo "source venv/bin/activate" >> $BASH_ENV
+      - run:
           name: "Install Python Bindings"
           command: |
-            pip3 install packaging && \
-            pip3 install numpy && \
+            pip install packaging && \
+            pip install numpy && \
             cd bindings/python && \
-            USE_CUDA=<< parameters.use_cuda >> python3 setup.py install
+            USE_CUDA=<< parameters.use_cuda >> python setup.py install
   run_python_tests:
     steps:
       - run:
           name: "Run Python Binding Tests"
           command: |
             cd bindings/python/test &&  \
-            python3 -m unittest discover -v .
+            python -m unittest discover -v .
   test_with_external_project:
     parameters:
       build_shared_libs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,8 @@ commands:
           command: |
             pip3 install packaging && \
             pip3 install numpy && \
-            USE_CUDA=<< parameters.use_cuda >> pip3 install -e bindings/python
+            cd bindings/python && \
+            USE_CUDA=<< parameters.use_cuda >> python3 setup.py install
   run_python_tests:
     steps:
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 build
 release
 debug
-*.so
 
 # FB
 fb
@@ -41,6 +40,12 @@ wheels/
 *.lo
 *.o
 *.obj
+
+# Compiled Dynamic libraries
+*.so
+*.so.*
+*.dylib
+*.dll
 
 # Compiled Static libraries
 *.lai

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 Flashlight Sequence has Python bindings. To install the bindings from source, [optionally install CUDA] then clone the repo and build:
 ```shell
 git clone https://github.com/flashlight/sequence && cd sequence
-pip install -e bindings/python
+cd bindings/python
+python setup.py install
 ```
 To install with CUDA support, set the environment variable `USE_CUDA=1` when running the install command.
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -17,8 +17,15 @@
 
 Once the dependencies are satisfied, from the project root, use:
 ```
-pip install -e bindings/python
+cd bindings/python
+python setup.py install
 ```
+
+or locally in editable mode (`-e` is required as libs are built outside of the bindings directory)
+```
+pip install -e .
+```
+
 (`pypi` installation coming soon)
 
 **Note:** if you encounter errors, you'll probably have to `rm -rf build dist` before retrying the install.

--- a/bindings/python/flashlight/lib/sequence/__init__.py
+++ b/bindings/python/flashlight/lib/sequence/__init__.py
@@ -6,4 +6,4 @@ This source code is licensed under the MIT-style license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-name = 'sequence'
+name = "sequence"

--- a/bindings/python/flashlight/lib/sequence/__init__.py
+++ b/bindings/python/flashlight/lib/sequence/__init__.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+name = 'sequence'

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -101,7 +101,6 @@ setup(
     author_email="oncall+flashlight@xmail.facebook.com",
     description="Flashlight Sequence bindings for python",
     long_description="",
-    namespace_packages=["flashlight", "flashlight.lib"],
     packages=["flashlight.lib.sequence"],
     ext_modules=[
         CMakeExtension("flashlight.lib.sequence.criterion"),


### PR DESCRIPTION
See title. Stop using `namespace_packages` since it's deprecated, and follow the official docs which stipulate removing `__init__.py` from every namespace dir that doesn't actually have package assets.

Test plan: tested install combos, i.e.
text:
```
conda create -n flashlight-python python=3.10
conda activate flashlight-python
cd text/bindings/python
USE_KENLM=0 python setup.py install
```
sequence:
```
cd sequence/bindings/python
USE_CUDA=0 python setup.py install
```
then test incremental install
```
python
> from flashlight.lib.text import decoder
> from flashlight.lib.sequence import criterion
```
then remove things:
```
pip uninstall flashlight-text
python
> from flashlight.lib.sequence import criterion
```
remove everything
```
pip uninstall flashlight-sequence
python
> import flashlight
>> ModuleNotFoundError: No module named 'flashlight'
```