### PR TITLE
Add explicit NVIDIA cub check/standalone mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,6 @@ if(CCACHE_PROGRAM)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(FL_SEQUENCE_CODE_COVERAGE "Enable coverage reporting" OFF)
 
@@ -33,10 +31,16 @@ include(${PROJECT_SOURCE_DIR}/cmake/InternalUtils.cmake)
 option(FL_SEQUENCE_USE_CUDA "Build with CUDA support" OFF)
 option(FL_SEQUENCE_BUILD_TESTS "Build tests" ON)
 option(FL_SEQUENCE_BUILD_PYTHON "Build Python bindings" OFF)
+option(FL_SEQUENCE_BUILD_STANDALONE "Build standalone installation" ON)
 
 # ------------------------ Build ------------------------
 
 add_library(flashlight-sequence)
+
+set_target_properties(flashlight-sequence PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED ON
+  )
 
 target_include_directories(
   flashlight-sequence
@@ -46,6 +50,15 @@ target_include_directories(
 
 if (FL_SEQUENCE_USE_CUDA)
   enable_language(CUDA)
+
+  # To support nvcc with CUDA < 11
+  set_target_properties(
+    flashlight-sequence
+    PROPERTIES
+    CUDA_STANDARD 14
+    CUDA_STANDARD_REQUIRED ON
+    )
+
   target_compile_definitions(
     flashlight-sequence
     PUBLIC
@@ -58,6 +71,8 @@ include(${PROJECT_SOURCE_DIR}/flashlight/lib/sequence/CMakeLists.txt)
 if (FL_SEQUENCE_BUILD_PYTHON)
   include(${PROJECT_SOURCE_DIR}/bindings/python/CMakeLists.txt)
 endif()
+
+add_library(flashlight::flashlight-sequence ALIAS flashlight-sequence)
 
 # ------------------------ Tests + Code Coverage------------------------
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ make install # install at the CMAKE_INSTALL_PREFIX
 ```
 To enable CUDA while building, pass `-DFL_SEQUENCE_USE_CUDA=ON` to CMake. To disable building tests, pass `-DFL_SEQUENCE_BUILD_TESTS=OFF`.
 
+If building with CUDA < 11, [NVIDIA cub](https://github.com/NVIDIA/cub) is required. It will be downloaded automatically if not found; the `FL_SEQUENCE_BUILD_STANDALONE` build option controls this behavior.
+
 ### Adding Flashlight Sequence to a C++ Project
 
 Given a simple `project.cpp` file that includes and links to Flashlight Sequence:

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -5,8 +5,8 @@ if (NOT BUILD_SHARED_LIBS)
     "set BUILD_SHARED_LIBS to ON.")
 endif()
 
-include(${CMAKE_MODULE_PATH}/Buildpybind11.cmake)
-include(${CMAKE_MODULE_PATH}/pybind11Tools.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/Buildpybind11.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/pybind11Tools.cmake)
 
 function (add_pybind11_extension ext_name)
   string(REPLACE "_" ";" modlist ${ext_name})

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -61,6 +61,7 @@ class CMakeBuild(build_ext):
             "-DBUILD_SHARED_LIBS=ON",
             "-DFL_SEQUENCE_BUILD_TESTS=OFF",
             "-DFL_SEQUENCE_BUILD_PYTHON=ON",
+            "-DFL_SEQUENCE_BUILD_STANDALONE=OFF",
             "-DFL_SEQUENCE_USE_CUDA=" + use_cuda,
         ]
         cfg = "Debug" if self.debug else "Release"

--- a/cmake/Buildcub.cmake
+++ b/cmake/Buildcub.cmake
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+
+include(FetchContent)
+
+FetchContent_Declare(
+  cub
+  GIT_REPOSITORY https://github.com/NVIDIA/cub.git
+  # guaranteed to work with CUDA < 11, where it isn't bundled
+  GIT_TAG        1.8.0
+  )
+
+FetchContent_MakeAvailable(cub)
+set(cub_INCLUDE_DIRS ${cub_SOURCE_DIR})

--- a/cmake/TestUtils.cmake
+++ b/cmake/TestUtils.cmake
@@ -8,7 +8,7 @@ if (NOT GTEST_FOUND)
   if (NOT TARGET gtest)
     message(STATUS "googletest not found - will download and build from source")
     # Download, build, and find the resulting googletest
-    include(${CMAKE_MODULE_PATH}/BuildGoogleTest.cmake)
+    include(${PROJECT_SOURCE_DIR}/cmake/BuildGoogleTest.cmake)
     list(APPEND GTEST_TARGETS GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
   endif()
 else()

--- a/flashlight/lib/sequence/criterion/CMakeLists.txt
+++ b/flashlight/lib/sequence/criterion/CMakeLists.txt
@@ -14,6 +14,25 @@ target_sources(
   )
 
 if (FL_SEQUENCE_USE_CUDA)
+  # cub is required for BlockReduce and not bundled with CUDA < 11
+  find_path(cub_INCLUDE_DIRS
+    NAMES cub.cuh
+    PATH_SUFFIXES cub include
+    PATHS ${cub_BASE_DIR} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}
+    ENV ${cub_BASE_DIR})
+  if (NOT cub_INCLUDE_DIRS)
+    if (NOT FL_SEQUENCE_BUILD_STANDALONE)
+      message(FATAL_ERROR
+        "Required dependency NVIDIA cub not found - try setting cub_BASE_DIR")
+    endif()
+
+    message(STATUS "NVIDIA cub not found - downloading from source")
+    include(${PROJECT_SOURCE_DIR}/cmake/Buildcub.cmake)
+    target_include_directories(flashlight-sequence PRIVATE ${cub_INCLUDE_DIRS})
+  else()
+    message(STATUS "NVIDIA cub found: (include: ${cub_INCLUDE_DIRS})")
+  endif()
+
   target_sources(
     flashlight-sequence
     PRIVATE


### PR DESCRIPTION
Build improvements, including:
- Add a `FetchContent` implementation that automatically pulls in NVIDIA cub if not found. Will be found on systems with new CUDA versions
- improves use with `FetchContent` by providing an alias that resembles an `IMPORTED` target, i.e. `flashlight::flashlight-sequence` for in-source builds

Test plan: CI +

Testing with an old CUDA version to confirm cub headers are properly downloaded and used (requires gcc < 7 for CUDA < 11)
```bash
module load cuda/9.2

export CXX=/public/apps/gcc/6.3.0/bin/g++
export CC=/public/apps/gcc/6.3.0/bin/gcc
export PATH=/public/apps/gcc/6.3.0/bin:$PATH # prepend

cmake .. -DFL_SEQUENCE_USE_CUDA=ON
```
the build succeeds as is with CUDA >= 11, and rightfully fails with CUDA < 11 with `FL_SEQUENCE_BUILD_STANDALONE` disabled:
```
cmake .. -DFL_SEQUENCE_USE_CUDA=ON -DFL_SEQUENCE_BUILD_STANDALONE=OFF
```
