### PR TITLE
Update docs for PEP 517 install/pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,17 @@
 Flashlight Sequence has Python bindings. To install the bindings from source, [optionally install CUDA] then clone the repo and build:
 ```shell
 git clone https://github.com/flashlight/sequence && cd sequence
-cd bindings/python
-python setup.py install
+pip install .
 ```
 To install with CUDA support, set the environment variable `USE_CUDA=1` when running the install command.
 
 See the [full Python binding documentation](bindings/python) for examples and more.
 
 ## Building and Installing
-[**From Source (C++)**](#building-from-source) | [**From Source (Python)**](bindings/python#build-instructions) | [**Adding to Your Own Project (C++)**](#adding-flashlight-sequence-to-a-c++-project)
+[**From Source (C++)**](#building-from-source) | [**From Source (Python)**](bindings/python#build-instructions) | [**Adding to Your Own Project (C++)**](#adding-flashlight-sequence-to-a-c-project)
 
 ### Requirements
-At minimum, compilation requires:
+At minimum, C++ compilation requires:
 - A C++ compiler with good C++17 support (e.g. gcc/g++ >= 7)
 - [CMake](https://cmake.org/) — version 3.16 or later, and ``make``
 - A Linux-based operating system.

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -7,18 +7,12 @@
 - [Python API Documentation](#python-api-documentation)
 
 ## Installation
-### Dependencies
-`python >= 3.6` is required with the following packages installed:
-- [packaging](https://pypi.org/project/packaging/)
-- [cmake](https://cmake.org/) >= 3.18, and `make`
-- CUDA is optionally required.
+CUDA is required if building CUDA kernel implementations with the Python package.
 
 ### Build Instructions
-
-Once the dependencies are satisfied, from the project root, use:
+From the project root, run:
 ```
-cd bindings/python
-python setup.py install
+pip install .
 ```
 
 or locally in editable mode (`-e` is required as libs are built outside of the bindings directory)
@@ -27,8 +21,6 @@ pip install -e .
 ```
 
 (`pypi` installation coming soon)
-
-**Note:** if you encounter errors, you'll probably have to `rm -rf build dist` before retrying the install.
 
 ### Advanced Options
 - `USE_CUDA=1` builds CUDA kernels for many included algorithms. CUDA >= 9 is required.


### PR DESCRIPTION
See title. Don't recommend `setup.py install` and remove all mentions of build dependencies since `pyproject.toml` does everything.

Test plan: inspect