### PR TITLE
Explicitly export library symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ target_include_directories(
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   )
 
+target_compile_definitions(flashlight-sequence PUBLIC FL_SEQ_DLL)
+
 if (FL_SEQUENCE_USE_CUDA)
   enable_language(CUDA)
 

--- a/flashlight/lib/sequence/Defines.h
+++ b/flashlight/lib/sequence/Defines.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if defined(_WIN32) || defined(_MSC_VER)
+
+#ifdef FL_SEQ_DLL
+#define FL_SEQ_API __declspec(dllexport)
+#else // FL_SEQ_DLL
+#define FL_SEQ_API __declspec(dllimport)
+#endif // FL_SEQ_DLL
+
+#define FL_SEQ_DEPRECATED(msg) __declspec(deprecated(msg)
+
+#else // defined(_WIN32) || defined(_MSC_VER)
+
+#define FL_SEQ_API __attribute__((visibility("default")))
+#define FL_SEQ_DEPRECATED(msg) __attribute__((deprecated(msg)))
+
+#endif // defined(_WIN32) || defined(_MSC_VER)

--- a/flashlight/lib/sequence/criterion/Defines.h
+++ b/flashlight/lib/sequence/criterion/Defines.h
@@ -18,6 +18,7 @@ enum class CriterionScaleMode {
   TARGET_SZ = 3,
   TARGET_SZ_SQRT = 4,
 };
+
 } // namespace seq
 } // namespace lib
 } // namespace fl

--- a/flashlight/lib/sequence/criterion/Workspace.h
+++ b/flashlight/lib/sequence/criterion/Workspace.h
@@ -58,6 +58,7 @@ class Workspace {
   const uintptr_t workspacePtr_;
   size_t offset_;
 };
+
 } // namespace seq
 } // namespace lib
 } // namespace fl

--- a/flashlight/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
@@ -15,7 +15,7 @@ namespace lib {
 namespace cpu {
 
 template <class Float>
-FL_SEQ_API struct ConnectionistTemporalClassificationCriterion {
+struct FL_SEQ_API ConnectionistTemporalClassificationCriterion {
   static size_t getWorkspaceSize(int B, int T, int N, int L);
 
   static void viterbi(

--- a/flashlight/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/ConnectionistTemporalClassificationCriterion.h
@@ -8,12 +8,14 @@
 
 #include <cstddef>
 
+#include "flashlight/lib/sequence/Defines.h"
+
 namespace fl {
 namespace lib {
 namespace cpu {
 
 template <class Float>
-struct ConnectionistTemporalClassificationCriterion {
+FL_SEQ_API struct ConnectionistTemporalClassificationCriterion {
   static size_t getWorkspaceSize(int B, int T, int N, int L);
 
   static void viterbi(

--- a/flashlight/lib/sequence/criterion/cpu/CriterionUtils.cpp
+++ b/flashlight/lib/sequence/criterion/cpu/CriterionUtils.cpp
@@ -11,6 +11,8 @@
 #include <cmath>
 #include <vector>
 
+#include "flashlight/lib/sequence/criterion/Defines.h"
+
 namespace fl {
 namespace lib {
 namespace cpu {

--- a/flashlight/lib/sequence/criterion/cpu/CriterionUtils.h
+++ b/flashlight/lib/sequence/criterion/cpu/CriterionUtils.h
@@ -9,7 +9,7 @@
 
 #include <cstring>
 
-#include "flashlight/lib/sequence/criterion/Defines.h"
+#include "flashlight/lib/sequence/Defines.h"
 
 using fl::lib::seq::CriterionScaleMode;
 
@@ -19,7 +19,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-struct CriterionUtils {
+FL_SEQ_API struct CriterionUtils {
   static void batchTargetSize(
       int B,
       int L,

--- a/flashlight/lib/sequence/criterion/cpu/CriterionUtils.h
+++ b/flashlight/lib/sequence/criterion/cpu/CriterionUtils.h
@@ -9,6 +9,7 @@
 
 #include <cstring>
 
+#include "flashlight/lib/sequence//criterion/Defines.h"
 #include "flashlight/lib/sequence/Defines.h"
 
 using fl::lib::seq::CriterionScaleMode;

--- a/flashlight/lib/sequence/criterion/cpu/CriterionUtils.h
+++ b/flashlight/lib/sequence/criterion/cpu/CriterionUtils.h
@@ -20,7 +20,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-FL_SEQ_API struct CriterionUtils {
+struct FL_SEQ_API CriterionUtils {
   static void batchTargetSize(
       int B,
       int L,

--- a/flashlight/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
@@ -8,8 +8,12 @@
 #pragma once
 
 #include <cstddef>
+
 #include "flashlight/lib/sequence/criterion/Defines.h"
+#include "flashlight/lib/sequence/Defines.h"
+
 using fl::lib::seq::CriterionScaleMode;
+
 
 namespace fl {
 namespace lib {
@@ -17,7 +21,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-struct ForceAlignmentCriterion {
+FL_SEQ_API struct ForceAlignmentCriterion {
   static size_t getWorkspaceSize(int B, int T, int N, int L);
 
   static void forward(

--- a/flashlight/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
@@ -20,7 +20,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-FL_SEQ_API struct ForceAlignmentCriterion {
+struct FL_SEQ_API ForceAlignmentCriterion {
   static size_t getWorkspaceSize(int B, int T, int N, int L);
 
   static void forward(

--- a/flashlight/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/ForceAlignmentCriterion.h
@@ -9,11 +9,10 @@
 
 #include <cstddef>
 
-#include "flashlight/lib/sequence/criterion/Defines.h"
 #include "flashlight/lib/sequence/Defines.h"
+#include "flashlight/lib/sequence/criterion/Defines.h"
 
 using fl::lib::seq::CriterionScaleMode;
-
 
 namespace fl {
 namespace lib {

--- a/flashlight/lib/sequence/criterion/cpu/FullConnectionCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/FullConnectionCriterion.h
@@ -9,8 +9,8 @@
 
 #include <cstddef>
 
-#include "flashlight/lib/sequence/criterion/Defines.h"
 #include "flashlight/lib/sequence/Defines.h"
+#include "flashlight/lib/sequence/criterion/Defines.h"
 
 using fl::lib::seq::CriterionScaleMode;
 

--- a/flashlight/lib/sequence/criterion/cpu/FullConnectionCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/FullConnectionCriterion.h
@@ -20,7 +20,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-FL_SEQ_API struct FullConnectionCriterion {
+struct FL_SEQ_API FullConnectionCriterion {
   static size_t getWorkspaceSize(int B, int T, int N);
 
   static void forward(

--- a/flashlight/lib/sequence/criterion/cpu/FullConnectionCriterion.h
+++ b/flashlight/lib/sequence/criterion/cpu/FullConnectionCriterion.h
@@ -10,6 +10,8 @@
 #include <cstddef>
 
 #include "flashlight/lib/sequence/criterion/Defines.h"
+#include "flashlight/lib/sequence/Defines.h"
+
 using fl::lib::seq::CriterionScaleMode;
 
 namespace fl {
@@ -18,7 +20,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-struct FullConnectionCriterion {
+FL_SEQ_API struct FullConnectionCriterion {
   static size_t getWorkspaceSize(int B, int T, int N);
 
   static void forward(

--- a/flashlight/lib/sequence/criterion/cpu/ViterbiPath.h
+++ b/flashlight/lib/sequence/criterion/cpu/ViterbiPath.h
@@ -9,13 +9,15 @@
 
 #include <cstddef>
 
+#include "flashlight/lib/sequence/Defines.h"
+
 namespace fl {
 namespace lib {
 namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-struct ViterbiPath {
+FL_SEQ_API struct ViterbiPath {
   static size_t getWorkspaceSize(int B, int T, int N);
 
   static void compute(

--- a/flashlight/lib/sequence/criterion/cpu/ViterbiPath.h
+++ b/flashlight/lib/sequence/criterion/cpu/ViterbiPath.h
@@ -17,7 +17,7 @@ namespace cpu {
 
 /// Check CUDA header for docs.
 template <class Float>
-FL_SEQ_API struct ViterbiPath {
+struct FL_SEQ_API ViterbiPath {
   static size_t getWorkspaceSize(int B, int T, int N);
 
   static void compute(

--- a/flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh
@@ -46,7 +46,7 @@ namespace lib {
 namespace cuda {
 
 template <class Float>
-FL_SEQ_API struct CriterionUtils {
+struct FL_SEQ_API CriterionUtils {
   /**
    * B: batch size
    * L: target size

--- a/flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/CriterionUtils.cuh
@@ -13,6 +13,8 @@
 #include <cstddef>
 
 #include "flashlight/lib/sequence/criterion/Defines.h"
+#include "flashlight/lib/sequence/Defines.h"
+
 using fl::lib::seq::CriterionScaleMode;
 
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 600
@@ -44,7 +46,7 @@ namespace lib {
 namespace cuda {
 
 template <class Float>
-struct CriterionUtils {
+FL_SEQ_API struct CriterionUtils {
   /**
    * B: batch size
    * L: target size

--- a/flashlight/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
@@ -10,6 +10,8 @@
 #include <cuda_runtime.h>
 
 #include "flashlight/lib/sequence/criterion/Defines.h"
+#include "flashlight/lib/sequence/Defines.h"
+
 using fl::lib::seq::CriterionScaleMode;
 
 namespace fl {
@@ -18,7 +20,7 @@ namespace cuda {
 
 /// The numerator of ASG loss. Reference: https://arxiv.org/abs/1609.03193
 template <class Float>
-struct ForceAlignmentCriterion {
+FL_SEQ_API struct ForceAlignmentCriterion {
   /**
    * B: batch size
    * T: input length

--- a/flashlight/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/ForceAlignmentCriterion.cuh
@@ -20,7 +20,7 @@ namespace cuda {
 
 /// The numerator of ASG loss. Reference: https://arxiv.org/abs/1609.03193
 template <class Float>
-FL_SEQ_API struct ForceAlignmentCriterion {
+struct FL_SEQ_API ForceAlignmentCriterion {
   /**
    * B: batch size
    * T: input length

--- a/flashlight/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
@@ -20,7 +20,7 @@ namespace cuda {
 
 /// The denominator of ASG loss. Reference: https://arxiv.org/abs/1609.03193
 template <class Float>
-FL_SEQ_API struct FullConnectionCriterion {
+struct FL_SEQ_API FullConnectionCriterion {
   /**
    * B: batch size
    * T: input length

--- a/flashlight/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/FullConnectionCriterion.cuh
@@ -10,6 +10,8 @@
 #include <cuda_runtime.h>
 
 #include "flashlight/lib/sequence/criterion/Defines.h"
+#include "flashlight/lib/sequence/Defines.h"
+
 using fl::lib::seq::CriterionScaleMode;
 
 namespace fl {
@@ -18,7 +20,7 @@ namespace cuda {
 
 /// The denominator of ASG loss. Reference: https://arxiv.org/abs/1609.03193
 template <class Float>
-struct FullConnectionCriterion {
+FL_SEQ_API struct FullConnectionCriterion {
   /**
    * B: batch size
    * T: input length

--- a/flashlight/lib/sequence/criterion/cuda/ViterbiPath.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/ViterbiPath.cuh
@@ -17,7 +17,7 @@ namespace cuda {
 
 /// Computes max likelihood path using Viterbi algorithm.
 template <class Float>
-FL_SEQ_API struct ViterbiPath {
+struct FL_SEQ_API ViterbiPath {
   /**
    * B: batch size
    * T: input length

--- a/flashlight/lib/sequence/criterion/cuda/ViterbiPath.cuh
+++ b/flashlight/lib/sequence/criterion/cuda/ViterbiPath.cuh
@@ -9,13 +9,15 @@
 
 #include <cuda_runtime.h>
 
+#include "flashlight/lib/sequence/Defines.h"
+
 namespace fl {
 namespace lib {
 namespace cuda {
 
 /// Computes max likelihood path using Viterbi algorithm.
 template <class Float>
-struct ViterbiPath {
+FL_SEQ_API struct ViterbiPath {
   /**
    * B: batch size
    * T: input length

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ class CMakeBuild(build_ext):
 
         if platform.system() == "Windows":
             cmake_args += [
-                "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON",
                 "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), ext_dir),
                 "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), ext_dir),
                 "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), ext_dir),


### PR DESCRIPTION
### Summary
Explicitly export symbols with visibility to avoid using the bad `WINDOWS_EXPORT_ALL_SYMBOLS` option.

Test plan: CI, local test
