### PR TITLE
Make building with OpenMP configurable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ commands:
           command: echo 'export PATH="$PATH:/c/Program Files/CMake/bin"' >> $BASH_ENV
   build_flashlight_sequence:
     parameters:
+      use_openmp:
+        type: string
+        default: "ON"
       use_cuda:
         type: string
         default: "ON"
@@ -80,6 +83,7 @@ commands:
             mkdir build && \
             cmake -S . -B build \
               -DBUILD_SHARED_LIBS=<< parameters.build_shared_libs >> \
+              -DFL_SEQUENCE_USE_OPENMP=<< parameters.use_openmp >> \
               -DFL_SEQUENCE_USE_CUDA=<< parameters.use_cuda >> \
               -DFL_SEQUENCE_CODE_COVERAGE=<< parameters.build_code_coverage >>
             cmake --build build --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/InternalUtils.cmake)
 
 # ----------------------------- Configuration -----------------------------
 
+option(FL_SEQUENCE_USE_OPENMP "Build with OpenMP support" OFF)
 option(FL_SEQUENCE_USE_CUDA "Build with CUDA support" OFF)
 option(FL_SEQUENCE_BUILD_TESTS "Build tests" ON)
 option(FL_SEQUENCE_BUILD_PYTHON "Build Python bindings" OFF)
@@ -63,6 +64,7 @@ if (FL_SEQUENCE_USE_CUDA)
   target_compile_definitions(
     flashlight-sequence
     PUBLIC
+    FL_SEQUENCE_USE_OPENMP
     FL_SEQUENCE_USE_CUDA
   )
 endif()

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Flashlight Sequence has Python bindings. To install the bindings from source, [o
 git clone https://github.com/flashlight/sequence && cd sequence
 pip install .
 ```
-To install with CUDA support, set the environment variable `USE_CUDA=1` when running the install command.
+To install with CUDA support, set the environment variable `USE_CUDA=1` when running the install command. By default, bindings are installed with OpenMP support; to build and install without OpenMP, set USE_OPENMP=0 when buildling.
 
 See the [full Python binding documentation](bindings/python) for examples and more.
 
@@ -32,7 +32,7 @@ At minimum, C++ compilation requires:
 - [CMake](https://cmake.org/) — version 3.16 or later, and ``make``
 - A Linux-based operating system.
 
-**CUDA Support:** If building with CUDA support, CUDA >= 9 is recommended. To toggle CUDA support use the `FL_SEQUENCE_USE_CUDA` CMake option or the `USE_CUDA` environment variable when building the Python bindings.
+**CUDA Support:** If building with CUDA support, CUDA >= 9 is recommended. To toggle CUDA support use the `FL_SEQUENCE_USE_CUDA` CMake option or the `USE_CUDA` environment variable when building the Python bindings. To toggle OpenMP support, use the `FL_SEQUENCE_USE_OPENMP` CMake option or use the `USE_OPENMP` environment variable when building the Python bindings.
 
 **Tests:** If building tests, [Google Test](https://github.com/google/googletest) >= 1.12 is required, but is installed automatically on build if not found. The `FL_SEQUENCE_BUILD_TESTS` CMake option toggles building tests.
 
@@ -49,7 +49,7 @@ make -j$(nproc)
 make test    # run tests
 make install # install at the CMAKE_INSTALL_PREFIX
 ```
-To enable CUDA while building, pass `-DFL_SEQUENCE_USE_CUDA=ON` to CMake. To disable building tests, pass `-DFL_SEQUENCE_BUILD_TESTS=OFF`.
+To enable CUDA while building, pass `-DFL_SEQUENCE_USE_CUDA=ON` to CMake. To enable building with OpenMP, pass `-DFL_SEQUENCE_USE_OPENMP=ON` to CMake. To disable building tests, pass `-DFL_SEQUENCE_BUILD_TESTS=OFF`.
 
 If building with CUDA < 11, [NVIDIA cub](https://github.com/NVIDIA/cub) is required. It will be downloaded automatically if not found; the `FL_SEQUENCE_BUILD_STANDALONE` build option controls this behavior.
 

--- a/cmake/flashlight-sequence-config.cmake.in
+++ b/cmake/flashlight-sequence-config.cmake.in
@@ -20,16 +20,16 @@
 #
 
 # Dependencies
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 include(CMakeFindDependencyMacro)
-find_dependency(OpenMP)
+if (@FL_SEQUENCE_USE_OPENMP@)
+  find_dependency(OpenMP)
+endif()
 if (@FL_SEQUENCE_USE_CUDA@)
   # TODO: use FindCUDAToolkit after requiring CMake >= 3.17
   enable_language(CUDA)
 endif()
-# Remove this dir from module path
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
 # Config variables
+set(FL_SEQUENCE_USE_OPENMP @FL_SEQUENCE_USE_OPENMP@)
 set(FL_SEQUENCE_USE_CUDA @FL_SEQUENCE_USE_CUDA@)
 
 ################################################################################

--- a/flashlight/lib/sequence/criterion/CMakeLists.txt
+++ b/flashlight/lib/sequence/criterion/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.16)
 
-find_package(OpenMP REQUIRED)
-target_link_libraries(flashlight-sequence PRIVATE OpenMP::OpenMP_CXX)
+if (FL_SEQUENCE_USE_OPENMP)
+  find_package(OpenMP REQUIRED)
+  target_link_libraries(flashlight-sequence PRIVATE OpenMP::OpenMP_CXX)
+endif()
 
 target_sources(
   flashlight-sequence

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,10 @@ def check_env_flag(name, default=""):
     return os.getenv(name, default).upper() in ["ON", "1", "YES", "TRUE", "Y"]
 
 
+def check_negative_env_flag(name, default="") -> bool:
+    return os.getenv(name, default).upper() in ["OFF", "0", "NO", "FALSE", "N"]
+
+
 def get_local_version_suffix() -> str:
     date_suffix = datetime.datetime.now().strftime("%Y%m%d")
     git_hash = subprocess.check_output(
@@ -84,6 +88,7 @@ class CMakeBuild(build_ext):
         ext_dir = str(Path(self.get_ext_fullpath(ext.name)).absolute().parent)
         source_dir = str(Path(__file__).absolute().parent)
         use_cuda = "ON" if check_env_flag("USE_CUDA") else "OFF"
+        use_openmp = "OFF" if check_negative_env_flag("USE_OPENMP") else "ON"
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + ext_dir,
             "-DPython3_EXECUTABLE=" + sys.executable,
@@ -92,6 +97,7 @@ class CMakeBuild(build_ext):
             "-DFL_SEQUENCE_BUILD_PYTHON=ON",
             "-DFL_SEQUENCE_BUILD_PYTHON_PACKAGE=ON",
             "-DFL_SEQUENCE_BUILD_STANDALONE=OFF",
+            "-DFL_SEQUENCE_USE_OPENMP=" + use_openmp,
             "-DFL_SEQUENCE_USE_CUDA=" + use_cuda,
         ]
         cfg = "Debug" if self.debug else "Release"


### PR DESCRIPTION
Introduce a new build option, `FL_SEQUENCE_USE_OPENMP`, which toggles finding and linking OpenMP with the CMake build. This is always enable when building Python bindings since cython has OpenMP support.

This is needed for `vcpkg` since we'll want `openmp` to be a particular feature that enables the option.

Test plan: CI, local test